### PR TITLE
Update README.md: Add note about newline in voxelfile.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ conda install -c ifcopenshell voxelization_toolkit
   statement:
     text: slabs = create_geometry(file,include={"IfcSlab"})
 ```
-4. Now add a line:
-  `export_point_cloud(outmost_voxels, "outmost_voxels.obj")`
+4. Now add a line in `voxelfile.txt`:
+  `export_point_cloud(outmost_voxels, "outmost_voxels.obj")` (ensure the file ends with a newline)
 5. and rerun voxec.
 6. The exported file can now be visualized for example in Blender.
 


### PR DESCRIPTION
This PR updates the instructions to mention that voxelfile.txt must end with a newline. Without it, voxec fails to parse the file correctly. This minor clarification helps users avoid potential errors as I myself had to fiddle around wasting a few minutes.